### PR TITLE
The merge routine is a little bit fuzzy: There is a check for ...

### DIFF
--- a/source/class/com/zenesis/qx/upload/AbstractHandler.js
+++ b/source/class/com/zenesis/qx/upload/AbstractHandler.js
@@ -271,6 +271,9 @@ qx.Class.define("com.zenesis.qx.upload.AbstractHandler", {
         }
       }
       merge(this.__uploader);
+      var widget = file.getUploadWidget();
+      if (widget && (typeof widget.getParamNames == "function"))
+        merge(widget);
       if (typeof file.getParamNames == "function")
         merge(file.getUploadWidget());
       merge(file);


### PR DESCRIPTION
file.getParamNames and then the widget is merged. This leads to an error if the widget has not getParamNames.

This patch correct this