### PR TITLE
Fix premature upload handler creation during property init

### DIFF
--- a/source/class/com/zenesis/qx/upload/UploadMgr.js
+++ b/source/class/com/zenesis/qx/upload/UploadMgr.js
@@ -264,7 +264,9 @@ qx.Class.define("com.zenesis.qx.upload.UploadMgr", {
 
     // property apply
     _applyAutoUpload(value, oldValue) {
-      this.getUploadHandler().beginUploads();
+      if (value && this.__uploadHandler) {
+        this.__uploadHandler.beginUploads();
+      }
     },
 
     // property apply


### PR DESCRIPTION
## Summary

- `_applyAutoUpload` called `getUploadHandler()` unconditionally, which lazily creates `__uploadHandler` as a side effect
- Properties are applied in definition order during Qooxdoo object initialization: `autoUpload` is initialized before `requireMultipartFormData`
- By the time `_applyRequireMultipartFormData` runs, `__uploadHandler` is already set and throws: *"has no effect once uploads have started"*
- Fix: only call `beginUploads()` when `value` is true **and** the handler already exists — during init there are no queued files so it's a no-op anyway